### PR TITLE
Copy entire resources folder to output

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -25,8 +25,8 @@
 #define MAP_TILE_SIZE               64
 #define MAP_TILE_PIXELS             32
 
-#define DEBUG_FONT                  "consolas.ttf"
-#define GAME_FONT                   "abaddon_bold.ttf"
+#define DEBUG_FONT                  "resources/fonts/consolas.ttf"
+#define GAME_FONT                   "resources/fonts/abaddon_bold.ttf"
 #define GAME_FONT_SIZE              16
 #define GAME_FONT_COLOR             sfColor_fromRGB( 224, 224, 224 )
 #define DIALOG_BACKDROP_LIGHTCOLOR  sfColor_fromRGBA( 0, 0, 0, 192 )

--- a/src/render_objects.c
+++ b/src/render_objects.c
@@ -27,8 +27,8 @@ gmRenderObjects_t* gmRenderObjects_Create()
    gmRenderObjects_t* renderObjects = (gmRenderObjects_t*)gmAlloc( sizeof( gmRenderObjects_t ), sfTrue );
 
    // TODO: define these filenames somewhere?
-   renderObjects->mapTilesetTexture = gmTexture_CreateFromFile( "map_tileset.png" );
-   renderObjects->entitySpriteTexture = gmTexture_CreateFromFile( "entity.png" );
+   renderObjects->mapTilesetTexture = gmTexture_CreateFromFile( "resources/textures/tiles/map_tileset.png" );
+   renderObjects->entitySpriteTexture = gmTexture_CreateFromFile( "resources/textures/sprites/entity.png" );
 
    renderObjects->diagnostics = gmDiagnosticsRenderObjects_Create();
    renderObjects->debugBar = gmDebugBarRenderObjects_Create();

--- a/win/CGameBase.vcxproj
+++ b/win/CGameBase.vcxproj
@@ -61,9 +61,7 @@
     </Link>
     <PostBuildEvent>
       <Command>xcopy "C:\CSFML-2.5.1\bin\*.dll" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\fonts\*.*" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\textures\sprites\*.*" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\textures\tiles\*.*" "$(OutDir)" /Y</Command>
+xcopy "$(SolutionDir)..\src\resources" "$(OutDir)\resources\" /S /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -88,9 +86,7 @@ xcopy "$(SolutionDir)..\src\resources\textures\tiles\*.*" "$(OutDir)" /Y</Comman
     </Link>
     <PostBuildEvent>
       <Command>xcopy "C:\CSFML-2.5.1\bin\*.dll" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\fonts\*.*" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\textures\sprites\*.*" "$(OutDir)" /Y
-xcopy "$(SolutionDir)..\src\resources\textures\tiles\*.*" "$(OutDir)" /Y</Command>
+xcopy "$(SolutionDir)..\src\resources" "$(OutDir)\resources\" /S /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
## Overview

This copies the entire resources folder from `src` to the output destination. Now we can add files in there without having to make sure a post-build step copies them to the output folder.