### PR TITLE
Small refactor

### DIFF
--- a/src/clock.c
+++ b/src/clock.c
@@ -4,13 +4,13 @@ gmClock_t* gmClock_Create()
 {
    gmClock_t* clock = (gmClock_t*)gmAlloc( sizeof( gmClock_t ), sfTrue );
 
-   clock->innerClock = gmInnerClock_Create();
+   clock->sfmlClock = gmInnerClock_Create();
    clock->frameDeltaSeconds = 1.0f / GAME_FPS;
    clock->maxFrameDurationMicro = (sfInt64)( (double)clock->frameDeltaSeconds * 1000000 );
    clock->totalFrameCount = 0;
    clock->lagFrameCount = 0;
 
-   clock->absoluteStartMicro = sfClock_getElapsedTime( clock->innerClock ).microseconds;
+   clock->absoluteStartMicro = sfClock_getElapsedTime( clock->sfmlClock ).microseconds;
    clock->realTotalDurationMicro = 0;
 
    return clock;
@@ -18,19 +18,19 @@ gmClock_t* gmClock_Create()
 
 void gmClock_Destroy( gmClock_t* clock )
 {
-   gmInnerClock_Destroy( clock->innerClock );
+   gmInnerClock_Destroy( clock->sfmlClock );
 
    gmFree( clock, sizeof( gmClock_t ), sfTrue );
 }
 
 void gmClock_StartFrame( gmClock_t* clock )
 {
-   clock->frameStartTime = sfClock_getElapsedTime( clock->innerClock );
+   clock->frameStartTime = sfClock_getElapsedTime( clock->sfmlClock );
 }
 
 void gmClock_EndFrame( gmClock_t* clock )
 {
-   sfTime frameEndTime = sfClock_getElapsedTime( clock->innerClock );
+   sfTime frameEndTime = sfClock_getElapsedTime( clock->sfmlClock );
    sfTime sleepTime = { 0 };
    sfInt64 frameDurationMicro = frameEndTime.microseconds - clock->frameStartTime.microseconds;
 

--- a/src/clock.h
+++ b/src/clock.h
@@ -5,7 +5,7 @@
 
 typedef struct gmClock_t
 {
-   sfClock* innerClock;
+   sfClock* sfmlClock;
 
    float frameDeltaSeconds;
    sfInt64 maxFrameDurationMicro;

--- a/src/common.c
+++ b/src/common.c
@@ -29,13 +29,13 @@ void gmLog_Msg( const char* msg )
    FILE* logFile = 0;
    time_t t = time( 0 );
    struct tm* tm;
-   char errorMsg[DEFAULT_STRLEN];
+   char errorMsg[STRLEN_DEFAULT];
 
    logFile = fopen( LOG_FILENAME, "a" );
 
    if ( !logFile )
    {
-      snprintf( errorMsg, DEFAULT_STRLEN, "%s: \"%s\"", STR_ERROR_OPENLOGFILE, msg );
+      snprintf( errorMsg, STRLEN_DEFAULT, "%s: \"%s\"", STR_ERROR_OPENLOGFILE, msg );
       gmExitWithError( errorMsg );
    }
 
@@ -45,7 +45,7 @@ void gmLog_Msg( const char* msg )
    {
       if ( fprintf( logFile, msg ) < 0 )
       {
-         snprintf( errorMsg, DEFAULT_STRLEN, "%s: \"%s\"", STR_ERROR_WRITELOGFILE, msg );
+         snprintf( errorMsg, STRLEN_DEFAULT, "%s: \"%s\"", STR_ERROR_WRITELOGFILE, msg );
          gmExitWithError( errorMsg );
       }
    }
@@ -56,7 +56,7 @@ void gmLog_Msg( const char* msg )
                      tm->tm_hour, tm->tm_min, tm->tm_sec,
                      msg ) < 0 )
       {
-         snprintf( errorMsg, DEFAULT_STRLEN, "%s: \"%s\"", STR_ERROR_WRITELOGFILE, msg );
+         snprintf( errorMsg, STRLEN_DEFAULT, "%s: \"%s\"", STR_ERROR_WRITELOGFILE, msg );
          gmExitWithError( errorMsg );
       }
    }
@@ -74,8 +74,8 @@ void gmLog_Newline()
 
 void gmExitWithError( const char* msg )
 {
-   char output[DEFAULT_STRLEN];
-   snprintf( output, DEFAULT_STRLEN, "%s: %s\n\n", STR_ERROR, msg );
+   char output[STRLEN_DEFAULT];
+   snprintf( output, STRLEN_DEFAULT, "%s: %s\n\n", STR_ERROR, msg );
    printf( output );
    exit( 1 );
 }

--- a/src/common.h
+++ b/src/common.h
@@ -8,8 +8,8 @@
 
 #include "strings.h"
 
-#define DEFAULT_STRLEN  512
-#define SHORT_STRLEN    32
+#define STRLEN_DEFAULT  512
+#define STRLEN_SHORT    32
 
 #define LOG_FILENAME    "log.txt"
 

--- a/src/game.c
+++ b/src/game.c
@@ -2,6 +2,7 @@
 #include "window.h"
 #include "clock.h"
 #include "input_state.h"
+#include "input_handler.h"
 #include "renderer.h"
 #include "render_states.h"
 
@@ -39,7 +40,7 @@ void gmGame_Run( gmGame_t* game )
 
       gmInputState_Reset( game->inputState );
       gmWindow_HandleEvents( game->window, game->inputState );
-      gmGame_HandleInput( game );
+      gmInputHandler_HandleInput( game );
       gmGame_Tic( game );
       gmRenderer_Render( game );
 

--- a/src/game.c
+++ b/src/game.c
@@ -2,8 +2,10 @@
 #include "window.h"
 #include "clock.h"
 #include "input_state.h"
-#include "render_objects.h"
+#include "renderer.h"
 #include "render_states.h"
+
+static void gmGame_Tic( gmGame_t* game );
 
 gmGame_t* gmGame_Create()
 {
@@ -12,8 +14,7 @@ gmGame_t* gmGame_Create()
    game->window = gmWindow_Create();
    game->clock = gmClock_Create();
    game->inputState = gmInputState_Create();
-   game->renderObjects = gmRenderObjects_Create();
-   game->renderStates = gmRenderStates_Create();
+   game->renderer = gmRenderer_Create();
 
    game->showDiagnostics = sfFalse;
 
@@ -22,8 +23,7 @@ gmGame_t* gmGame_Create()
 
 void gmGame_Destroy( gmGame_t* game )
 {
-   gmRenderStates_Destroy( game->renderStates );
-   gmRenderObjects_Destroy( game->renderObjects );
+   gmRenderer_Destroy( game->renderer );
    gmInputState_Destroy( game->inputState );
    gmClock_Destroy( game->clock );
    gmWindow_Destroy( game->window );
@@ -40,8 +40,8 @@ void gmGame_Run( gmGame_t* game )
       gmInputState_Reset( game->inputState );
       gmWindow_HandleEvents( game->window, game->inputState );
       gmGame_HandleInput( game );
-      gmRenderStates_Tic( game->renderStates, game->clock );
-      gmGame_Render( game );
+      gmGame_Tic( game );
+      gmRenderer_Render( game );
 
       if ( game->window->wantToClose )
       {
@@ -52,6 +52,11 @@ void gmGame_Run( gmGame_t* game )
    }
 }
 
+static void gmGame_Tic( gmGame_t* game )
+{
+   gmRenderStates_Tic( game->renderer->renderStates, game->clock );
+}
+
 void gmGame_Close( gmGame_t* game )
 {
    gmWindow_Close( game->window );
@@ -59,7 +64,7 @@ void gmGame_Close( gmGame_t* game )
 
 void gmGame_ShowDebugMessage( gmGame_t* game, const char* msg )
 {
-   gmDebugBarRenderState_t* state = game->renderStates->debugBar;
+   gmDebugBarRenderState_t* state = game->renderer->renderStates->debugBar;
 
    snprintf( state->msgBuffer, state->msgBufferLen, "%s", msg );
    state->isVisible = sfTrue;

--- a/src/game.h
+++ b/src/game.h
@@ -25,7 +25,4 @@ void gmGame_Run( gmGame_t* game );
 void gmGame_Close( gmGame_t* game );
 void gmGame_ShowDebugMessage( gmGame_t* game, const char* msg );
 
-// input_handler.c
-void gmGame_HandleInput( gmGame_t* game );
-
 #endif // GAME_H

--- a/src/game.h
+++ b/src/game.h
@@ -6,16 +6,14 @@
 typedef struct gmWindow_t gmWindow_t;
 typedef struct gmClock_t gmClock_t;
 typedef struct gmInputState_t gmInputState_t;
-typedef struct gmRenderObjects_t gmRenderObjects_t;
-typedef struct gmRenderStates_t gmRenderStates_t;
+typedef struct gmRenderer_t gmRenderer_t;
 
 typedef struct gmGame_t
 {
    gmWindow_t* window;
    gmClock_t* clock;
    gmInputState_t* inputState;
-   gmRenderObjects_t* renderObjects;
-   gmRenderStates_t* renderStates;
+   gmRenderer_t* renderer;
 
    sfBool showDiagnostics;
 }
@@ -29,8 +27,5 @@ void gmGame_ShowDebugMessage( gmGame_t* game, const char* msg );
 
 // input_handler.c
 void gmGame_HandleInput( gmGame_t* game );
-
-// renderer.c
-void gmGame_Render( gmGame_t* game );
 
 #endif // GAME_H

--- a/src/input_handler.c
+++ b/src/input_handler.c
@@ -7,7 +7,7 @@ void gmInputHandler_HandleInput( gmGame_t* game )
    {
       gmGame_Close( game );
    }
-   else if ( gmInputState_WasKeyPressed( game->inputState, sfKeyD ) )
+   else if ( gmInputState_WasKeyPressed( game->inputState, sfKeyF8 ) )
    {
       TOGGLE_BOOL( game->showDiagnostics );
 

--- a/src/input_handler.c
+++ b/src/input_handler.c
@@ -1,7 +1,7 @@
 #include "game.h"
 #include "input_state.h"
 
-void gmGame_HandleInput( gmGame_t* game )
+void gmInputHandler_HandleInput( gmGame_t* game )
 {
    if ( gmInputState_WasKeyPressed( game->inputState, sfKeyEscape ) )
    {

--- a/src/input_handler.h
+++ b/src/input_handler.h
@@ -1,0 +1,10 @@
+#if !defined( INPUT_HANDLER_H )
+#define INPUT_HANDLER_H
+
+#include "common.h"
+
+typedef struct gmGame_t gmGame_t;
+
+void gmInputHandler_HandleInput( gmGame_t* game );
+
+#endif // INPUT_HANDLER_H

--- a/src/main.c
+++ b/src/main.c
@@ -2,7 +2,7 @@
 
 int main()
 {
-   char memStr[DEFAULT_STRLEN];
+   char memStr[STRLEN_DEFAULT];
 
    g_memAllocated = 0;
    g_memFreed = 0;
@@ -28,17 +28,17 @@ int main()
    gmGame_Destroy( game );
    printf( STR_CONSOLE_BURRITO );
 
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %llu", STR_MAIN_MEMALLOCATED, g_memAllocated );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %llu", STR_MAIN_MEMALLOCATED, g_memAllocated );
    gmLog_Msg( memStr );
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %llu", STR_MAIN_MEMFREED, g_memFreed );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %llu", STR_MAIN_MEMFREED, g_memFreed );
    gmLog_Msg( memStr );
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %llu", STR_MAIN_MEMMAX, g_maxMemCounter );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %llu", STR_MAIN_MEMMAX, g_maxMemCounter );
    gmLog_Msg( memStr );
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %u", STR_MAIN_SFMLOBJCREATED, g_sfmlObjectsCreated );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %u", STR_MAIN_SFMLOBJCREATED, g_sfmlObjectsCreated );
    gmLog_Msg( memStr );
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %u", STR_MAIN_SFMLOBJDESTROYED, g_sfmlObjectsDestroyed );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %u", STR_MAIN_SFMLOBJDESTROYED, g_sfmlObjectsDestroyed );
    gmLog_Msg( memStr );
-   snprintf( memStr, DEFAULT_STRLEN, "%s: %u", STR_MAIN_SFMLOBJMAX, g_maxSfmlObjectCounter );
+   snprintf( memStr, STRLEN_DEFAULT, "%s: %u", STR_MAIN_SFMLOBJMAX, g_maxSfmlObjectCounter );
    gmLog_Msg( memStr );
    gmLog_Newline();
 

--- a/src/render_objects.h
+++ b/src/render_objects.h
@@ -1,5 +1,5 @@
-#if !defined( RENDERER_H )
-#define RENDERER_H
+#if !defined( RENDER_OBJECTS_H )
+#define RENDER_OBJECTS_H
 
 #include "common.h"
 
@@ -33,5 +33,5 @@ gmRenderObjects_t;
 gmRenderObjects_t* gmRenderObjects_Create();
 void gmRenderObjects_Destroy( gmRenderObjects_t* renderObjects );
 
-#endif // RENDERER_H
+#endif // RENDER_OBJECTS_H
 

--- a/src/render_states.c
+++ b/src/render_states.c
@@ -20,8 +20,8 @@ static gmDebugBarRenderState_t* gmDebugBarRenderState_Create()
    state->isVisible = sfFalse;
    state->visibleSeconds = 3;
    state->elapsedSeconds = 0;
-   state->msgBuffer = (char*)gmCalloc( DEFAULT_STRLEN, sizeof( char ), sfTrue );
-   state->msgBufferLen = DEFAULT_STRLEN;
+   state->msgBuffer = (char*)gmCalloc( STRLEN_DEFAULT, sizeof( char ), sfTrue );
+   state->msgBufferLen = STRLEN_DEFAULT;
 
    return state;
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -24,34 +24,34 @@ void gmGame_Render( gmGame_t* game )
 
 static void gmRenderer_DrawDiagnostics( gmGame_t* game )
 {
-   char msg[DEFAULT_STRLEN];
-   char timeStr[SHORT_STRLEN];
+   char msg[STRLEN_DEFAULT];
+   char timeStr[STRLEN_SHORT];
    gmDiagnosticsRenderObjects_t* objects = game->renderObjects->diagnosticsRenderObjects;
 
    gmWindow_DrawRectangleShape( game->window, objects->backgroundRect );
 
    objects->textPosition.y = 4;
    sfText_setPosition( objects->text, objects->textPosition );
-   snprintf( msg, DEFAULT_STRLEN, STR_FRAMERATEFORMATTER, GAME_FPS );
+   snprintf( msg, STRLEN_DEFAULT, STR_FRAMERATEFORMATTER, GAME_FPS );
    sfText_setString( objects->text, msg );
    gmWindow_DrawText( game->window, objects->text );
 
    objects->textPosition.y += objects->lineSpacing;
    sfText_setPosition( objects->text, objects->textPosition );
-   snprintf( msg, DEFAULT_STRLEN, STR_TOTALFRAMESFORMATTER, game->clock->totalFrameCount );
+   snprintf( msg, STRLEN_DEFAULT, STR_TOTALFRAMESFORMATTER, game->clock->totalFrameCount );
    sfText_setString( objects->text, msg );
    gmWindow_DrawText( game->window, objects->text );
 
    objects->textPosition.y += objects->lineSpacing;
    sfText_setPosition( objects->text, objects->textPosition );
-   snprintf( msg, DEFAULT_STRLEN, STR_LAGFRAMESFORMATTER, game->clock->lagFrameCount );
+   snprintf( msg, STRLEN_DEFAULT, STR_LAGFRAMESFORMATTER, game->clock->lagFrameCount );
    sfText_setString( objects->text, msg );
    gmWindow_DrawText( game->window, objects->text );
 
    objects->textPosition.y += objects->lineSpacing;
    sfText_setPosition( objects->text, objects->textPosition );
-   dmTimeUtil_FormatTime( timeStr, SHORT_STRLEN, (int32_t)( game->clock->realTotalDurationMicro / 1000000 ) );
-   snprintf( msg, DEFAULT_STRLEN, STR_ELAPSEDTIMEFORMATTER, timeStr );
+   dmTimeUtil_FormatTime( timeStr, STRLEN_SHORT, (int32_t)( game->clock->realTotalDurationMicro / 1000000 ) );
+   snprintf( msg, STRLEN_DEFAULT, STR_ELAPSEDTIMEFORMATTER, timeStr );
    sfText_setString( objects->text, msg );
    gmWindow_DrawText( game->window, objects->text );
 }

--- a/src/renderer.c
+++ b/src/renderer.c
@@ -1,6 +1,7 @@
-#include "game.h"
+#include "renderer.h"
 #include "render_objects.h"
 #include "render_states.h"
+#include "game.h"
 #include "window.h"
 #include "clock.h"
 #include "time_util.h"
@@ -8,9 +9,27 @@
 static void gmRenderer_DrawDiagnostics( gmGame_t* game );
 static void gmRenderer_DrawDebugBar( gmGame_t* game );
 
-void gmGame_Render( gmGame_t* game )
+gmRenderer_t* gmRenderer_Create()
 {
-   gmWindow_DrawRectangleShape( game->window, game->renderObjects->windowBackgroundRect );
+   gmRenderer_t* renderer = (gmRenderer_t*)gmAlloc( sizeof( gmRenderer_t ), sfTrue );
+
+   renderer->renderObjects = gmRenderObjects_Create();
+   renderer->renderStates = gmRenderStates_Create();
+
+   return renderer;
+}
+
+void gmRenderer_Destroy( gmRenderer_t* renderer )
+{
+   gmRenderStates_Destroy( renderer->renderStates );
+   gmRenderObjects_Destroy( renderer->renderObjects );
+
+   gmFree( renderer, sizeof( gmRenderer_t ), sfTrue );
+}
+
+void gmRenderer_Render( gmGame_t* game )
+{
+   gmWindow_DrawRectangleShape( game->window, game->renderer->renderObjects->windowBackgroundRect );
 
    gmRenderer_DrawDebugBar( game );
 
@@ -26,7 +45,7 @@ static void gmRenderer_DrawDiagnostics( gmGame_t* game )
 {
    char msg[STRLEN_DEFAULT];
    char timeStr[STRLEN_SHORT];
-   gmDiagnosticsRenderObjects_t* objects = game->renderObjects->diagnosticsRenderObjects;
+   gmDiagnosticsRenderObjects_t* objects = game->renderer->renderObjects->diagnosticsRenderObjects;
 
    gmWindow_DrawRectangleShape( game->window, objects->backgroundRect );
 
@@ -58,8 +77,8 @@ static void gmRenderer_DrawDiagnostics( gmGame_t* game )
 
 static void gmRenderer_DrawDebugBar( gmGame_t* game )
 {
-   gmDebugBarRenderState_t* state = game->renderStates->debugBar;
-   gmDebugBarRenderObjects_t* objects = game->renderObjects->debugBarRenderObjects;
+   gmDebugBarRenderState_t* state = game->renderer->renderStates->debugBar;
+   gmDebugBarRenderObjects_t* objects = game->renderer->renderObjects->debugBarRenderObjects;
 
    if ( state->isVisible )
    {

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,0 +1,21 @@
+#if !defined( RENDERER_H )
+#define RENDERER_H
+
+#include "common.h"
+
+typedef struct gmRenderObjects_t gmRenderObjects_t;
+typedef struct gmRenderStates_t gmRenderStates_t;
+typedef struct gmGame_t gmGame_t;
+
+typedef struct gmRenderer_t
+{
+   gmRenderObjects_t* renderObjects;
+   gmRenderStates_t* renderStates;
+}
+gmRenderer_t;
+
+gmRenderer_t* gmRenderer_Create();
+void gmRenderer_Destroy( gmRenderer_t* renderer );
+void gmRenderer_Render( gmGame_t* game );
+
+#endif

--- a/src/window.c
+++ b/src/window.c
@@ -6,9 +6,9 @@ gmWindow_t* gmWindow_Create()
    sfVideoMode videoMode = { WINDOW_WIDTH, WINDOW_HEIGHT, WINDOW_BPP };
    gmWindow_t* window = (gmWindow_t*)gmAlloc( sizeof( gmWindow_t ), sfTrue );
 
-   window->innerWindow = gmRenderWindow_Create( videoMode, STR_WINDOW_TITLE, WINDOW_STYLE, 0 );
+   window->sfmlWindow = gmRenderWindow_Create( videoMode, STR_WINDOW_TITLE, WINDOW_STYLE, 0 );
 
-   sfRenderWindow_setKeyRepeatEnabled( window->innerWindow, sfFalse );
+   sfRenderWindow_setKeyRepeatEnabled( window->sfmlWindow, sfFalse );
    window->wantToClose = sfFalse;
 
    return window;
@@ -16,26 +16,26 @@ gmWindow_t* gmWindow_Create()
 
 void gmWindow_Destroy( gmWindow_t* window )
 {
-   gmRenderWindow_Destroy( window->innerWindow );
+   gmRenderWindow_Destroy( window->sfmlWindow );
 
    gmFree( window, sizeof( gmWindow_t ), sfTrue );
 }
 
 void gmWindow_Display( gmWindow_t* window )
 {
-   sfRenderWindow_display( window->innerWindow );
+   sfRenderWindow_display( window->sfmlWindow );
 }
 
 void gmWindow_Close( gmWindow_t* window )
 {
-   sfRenderWindow_close( window->innerWindow );
+   sfRenderWindow_close( window->sfmlWindow );
 }
 
 void gmWindow_HandleEvents( gmWindow_t* window, gmInputState_t* inputState )
 {
    sfEvent e;
 
-   while ( sfRenderWindow_pollEvent( window->innerWindow, &e ) )
+   while ( sfRenderWindow_pollEvent( window->sfmlWindow, &e ) )
    {
       switch ( e.type )
       {
@@ -54,15 +54,15 @@ void gmWindow_HandleEvents( gmWindow_t* window, gmInputState_t* inputState )
 
 void gmWindow_DrawRectangleShape( gmWindow_t* window, sfRectangleShape* rect )
 {
-   sfRenderWindow_drawRectangleShape( window->innerWindow, rect, 0 );
+   sfRenderWindow_drawRectangleShape( window->sfmlWindow, rect, 0 );
 }
 
 void gmWindow_DrawText( gmWindow_t* window, sfText* text )
 {
-   sfRenderWindow_drawText( window->innerWindow, text, 0 );
+   sfRenderWindow_drawText( window->sfmlWindow, text, 0 );
 }
 
 sfBool gmWindow_IsOpen( gmWindow_t* window )
 {
-   return sfRenderWindow_isOpen( window->innerWindow );
+   return sfRenderWindow_isOpen( window->sfmlWindow );
 }

--- a/src/window.h
+++ b/src/window.h
@@ -7,7 +7,7 @@ typedef struct gmInputState_t gmInputState_t;
 
 typedef struct gmWindow_t
 {
-   sfRenderWindow* innerWindow;
+   sfRenderWindow* sfmlWindow;
    sfBool wantToClose;
 }
 gmWindow_t;

--- a/win/CGameBase.vcxproj
+++ b/win/CGameBase.vcxproj
@@ -94,6 +94,7 @@ xcopy "$(SolutionDir)..\src\resources\fonts\*.*" "$(OutDir)" /Y</Command>
     <ClInclude Include="..\src\common.h" />
     <ClInclude Include="..\src\game.h" />
     <ClInclude Include="..\src\input_state.h" />
+    <ClInclude Include="..\src\renderer.h" />
     <ClInclude Include="..\src\render_objects.h" />
     <ClInclude Include="..\src\render_states.h" />
     <ClInclude Include="..\src\strings.h" />

--- a/win/CGameBase.vcxproj
+++ b/win/CGameBase.vcxproj
@@ -93,6 +93,7 @@ xcopy "$(SolutionDir)..\src\resources\fonts\*.*" "$(OutDir)" /Y</Command>
     <ClInclude Include="..\src\clock.h" />
     <ClInclude Include="..\src\common.h" />
     <ClInclude Include="..\src\game.h" />
+    <ClInclude Include="..\src\input_handler.h" />
     <ClInclude Include="..\src\input_state.h" />
     <ClInclude Include="..\src\renderer.h" />
     <ClInclude Include="..\src\render_objects.h" />


### PR DESCRIPTION
## Overview

I refactored a few things based on some stuff I ran into while developing the `game/dargonQuest` branch, I thought they'd be useful to add to main:

- All render objects and states should be part of a `gmRenderer_t` struct, instead of in the game object. It's easier to separate rendering from game logic this way.
- Likewise with input handling, that should go in its own file.
- Renamed all "innerWindow" and "innerClock" to "sfmlWindow" and "sfmlClock", just to be clear as to what they really are.
- Renamed the strlen macros to start with STRLEN instead of end with it. Somehow this was a huge headache in the other branch.
- The diagnostics key should be F8. That's what it is with other games I've made, since "D" will probably become a gameplay key (or cheat code key).